### PR TITLE
Install jinja2-2.9 or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 begins
 tqdm
-jinja2
+jinja2>=2.9


### PR DESCRIPTION
Required for the `select_autoescape` function, see also http://jinja.pocoo.org/docs/2.9/api/#autoescaping.