### PR TITLE
Create empty JSON object upon a HTTP 204 response

### DIFF
--- a/advanced.py
+++ b/advanced.py
@@ -18,7 +18,7 @@ class DataRetriever(object):
     def retrieve(self, url):
         if url not in self.cache:
             resp = requests.get(url=url, params=self.params)
-            data = json.loads(resp.text)
+            data = json.loads(resp.text or '[]')
             if 'next' in resp.links:
                 data.extend(self.retrieve(resp.links['next']['url']))
             self.cache[url] = data


### PR DESCRIPTION
`204` stands for 'no content' according to https://httpstatuses.com/. Previously, this resulted in a `JSONDecodeError` originated by passing an empty string to `json.loads` [here](https://github.com/asrob-uc3m/repostatistics/blob/99f76430eef6f24ae999ea5d93690f98e74e6226/advanced.py#L21):

```
Traceback (most recent call last):
  File "repostatistics.py", line 106, in <module>
    name='DUMMY', website='#'):
  File "/usr/local/lib/python3.5/dist-packages/begin/main.py", line 115, in _start
    prog.start()
  File "/usr/local/lib/python3.5/dist-packages/begin/main.py", line 54, in start
    collector=self._collector)
  File "/usr/local/lib/python3.5/dist-packages/begin/cmdline.py", line 253, in apply_options
    return_value = call_function(func, signature(ext), opts)
  File "/usr/local/lib/python3.5/dist-packages/begin/cmdline.py", line 236, in call_function
    return func(*pargs, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/begin/convert.py", line 92, in wrapper
    return func(*args, **kwargs)
  File "repostatistics.py", line 107, in main
    organization = extract_all_data(org_name=org, access_token=access_token)
  File "/home/bartek/git/asrob/repostatistics/advanced.py", line 107, in extract_all_data
    for contrib_data in dr.retrieve(repo_data['contributors_url']):
  File "/home/bartek/git/asrob/repostatistics/advanced.py", line 21, in retrieve
    data = json.loads(resp.text)
  File "/usr/lib/python3.5/json/__init__.py", line 319, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The ultimate cause was a request to https://api.github.com/repos/asrob-uc3m/Maquiavelo/contributors, which returns an empty response text (the [Maquiavelo repository](https://github.com/asrob-uc3m/Maquiavelo) has no content at the time of writing).

@jgvictores @David-Estevez I'm quite confident that a few latest script runs on the server crashed upon retrieving contributor's data for the asrob-uc3m org.